### PR TITLE
ChatGPT Markdown Translatorを使った自動翻訳の説明を追記

### DIFF
--- a/chatgpt-md-translator/.env
+++ b/chatgpt-md-translator/.env
@@ -1,0 +1,47 @@
+# Copy this to one of these locations based on your usage:
+#
+# $CWD/.chatgpt-md-translator
+# $CWD/.env
+# $HOME/.config/chatgpt-md-translator/config
+# $HOME/.chatgpt-md-translator
+
+# OpenAI's API Key. You will be charged for the usage of this key.
+OPENAI_API_KEY="YOUR_API_KEY"
+
+
+# =====================================
+# The remaining variables are optional.
+# =====================================
+
+# Base directory of the translated content.
+# BASE_DIR="/path/to/my/docs-project/content"
+
+# HTTPS Proxy (e.g, "https://proxy.example.com:8080")
+# We also read HTTPS_PROXY from regular environment variables.
+# HTTPS_PROXY=""
+
+# Default language model.
+MODEL_NAME="gpt-4-turbo"
+
+# Soft limit of the token size, used to split the file into fragments.
+# FRAGMENT_TOKEN_SIZE=2048
+
+# Sampling temperature, i.e., randomness of the generated text.
+# TEMPERATURE=0.1
+
+# If you hit the API rate limit, you can set this to a positive number.
+# API is not called more frequently than the given interval (in seconds).
+# API_CALL_INTERVAL=0
+
+# The maximum number of lines for code blocks
+# sent to the API as-is for context.
+# CODE_BLOCK_PRESERVATION_LINES=5
+
+# Transforms the input path to the output file path.
+# OUTPUT_FILE_PATTERN=""
+
+# What to do when the output file already exists. One of "overwite", "skip" and "abort".
+# OVERWRITE_POLICY="overwrite"
+
+# Custom API address, to integrate with a third-party API service provider.
+# API_ENDPOINT="https://api.openai.com/v1/chat/completions"

--- a/chatgpt-md-translator/prompt.md
+++ b/chatgpt-md-translator/prompt.md
@@ -1,0 +1,10 @@
+I am translating the documentation for Moddable SDK.
+Translate the Markdown content I'll paste later into Japanese.
+
+You must strictly follow the rules below.
+
+- Never change the Markdown markup structure. Don't add or remove links. Do not change any URL.
+- Never change the contents of code blocks even if they appear to have a bug.
+- Always preserve the original line breaks. Do not add or remove blank lines.
+- Never touch the permalink such as `{/*examples*/}` at the end of each heading.
+- Never touch HTML-like tags such as `<Notes>`.

--- a/translation_readme.md
+++ b/translation_readme.md
@@ -51,3 +51,14 @@ npm run textlint
 - 翻訳の進め方に関する相談、提案は [issue](https://github.com/Moddable-OpenSource/moddable-jp/issues/) で行います
 - issueを立てるまでもないカジュアルなやりとりなど、プロジェクトメンバー間のコミュニケーションには、 Discordサーバーを使用しています
 - [Discordサーバーの招待リンク](https://discord.gg/7vT4Mde9u2)から参加してください
+
+## 自動翻訳
+
+ChatGPTなどのAIを使った自動翻訳を利用できます。
+[`ChatGPT Markdown Translator`](https://github.com/smikitky/chatgpt-md-translator)を使うとマークダウンの文書単位で自動翻訳にかけることができます。
+ツールの設定例（`.env`と`prompt.md`）を[`chatgpt-md-translator`](./chatgpt-md-translator/)に置いていますので活用してください。
+
+### 注意点
+
+- `ChatGPT Markdown Translator`を使う際、出力ファイルのオプション（`-o`）を与えない場合は、**元ファイルを上書きする**挙動になるので注意してください
+- 出力される翻訳のクオリティは**80点程度**であり、誤訳や用語の表記ゆれを多く含みます。プルリクエストを作成する前に、**必ず全文を自身でチェックしてください**


### PR DESCRIPTION
ChatGPT Markdown Translatorを使った自動翻訳の説明を追記します。

同ツールを既に試されている @stc1988 さん、レビューをお願いできますでしょうか :pray:
個人的には

- ツールのセットアップ方法は外部リンクに任せてよいか
- 「注意点」で他に書いたほうがいいことあるか

が気になっています。