### PR TITLE
change default language model to `GPT-4o`

### DIFF
--- a/chatgpt-md-translator/.env
+++ b/chatgpt-md-translator/.env
@@ -21,7 +21,7 @@ OPENAI_API_KEY="YOUR_API_KEY"
 # HTTPS_PROXY=""
 
 # Default language model.
-MODEL_NAME="gpt-4-turbo"
+MODEL_NAME="gpt-4o"
 
 # Soft limit of the token size, used to split the file into fragments.
 # FRAGMENT_TOKEN_SIZE=2048


### PR DESCRIPTION
翻訳の自動化ツールとして使用している`chatgpt-md-translator`のデフォルトのモデルを`GPT-4o`に変更します
現在使用している`GPT-4 Turbo`に比べて自然な翻訳かつ早く安く対応できると予想されます。