### PR TITLE
documentation/piu 配下 の翻訳

### DIFF
--- a/documentation/piu/ae motion export.md
+++ b/documentation/piu/ae motion export.md
@@ -1,50 +1,51 @@
-# Using Adobe After Effects to export Moddable motion data
+# Adobe After Effectsを使用してModdableモーションデータをエクスポートする
 Copyright 2017 Moddable Tech, Inc.<BR>
-Revised: September 26, 2017
+改訂： 2017年9月26日
 
-## Introduction
+## はじめに
 
-Adobe After Effects can be used to export motion data into a Moddable sample app for use in development.
+Adobe After Effectsを使用して、モーションデータをModdableのサンプルアプリにエクスポートし、開発に使用することができます。
 
-Moddable motion control only supports position.
+Moddableのモーションコントロールは位置のみをサポートしています。
 
-In AE only layers with assets are exported and only positions are exported. Scaling, rotation, transparncy, etc. are not exported.
+AEでは、アセットを持つレイヤーのみがエクスポートされ、位置のみがエクスポートされます。スケーリング、回転、透明度などはエクスポートされません。
 
-Piu interpolates linearly between values in the array. You can reduce the frame rate in After Effects to reduce the size of the arrays. Piu will animate between values based on defined time length of the motion effect.
+Piuは配列内の値の間を線形補間します。After Effectsでフレームレートを下げることで、配列のサイズを小さくすることができます。Piuはモーションエフェクトの定義された時間長に基づいて値の間をアニメーション化します。
 
-### Installing the export script in After Effects
+### After Effectsにエクスポートスクリプトをインストールする
 
-Install the ae2piu.jsx script in the "scripts" folder within your After Effects application folder.
+ae2piu.jsxスクリプトをAfter Effectsアプリケーションフォルダ内の「scripts」フォルダにインストールします。
 
 <img src="../assets/ae-motion/ae_script_install.png" height="233"/>
 
 
 
 
-### Exporting motion data
+### モーションデータをエクスポートする
 
-To run the script select "ae2piu.jsx" from the File -> Scripts menu.
+スクリプトを実行するには、File -> Scriptsメニューから「ae2piu.jsx」を選択します。
 
 <img src="../assets/ae-motion//ae2piu-screen.png" width="600"/>
 
-When you run the export script in After Effects, it displays a dialog box to select a folder. Create a new folder the first time. The export script copies the assets and creates the manifest.json and main.js files for a complete Moddable application. To build the project and run in the Moddable Simulator use the following command.
+After Effectsでエクスポートスクリプトを実行すると、フォルダを選択するためのダイアログボックスが表示されます。最初に新しいフォルダを作成してください。エクスポートスクリプトはアセットをコピーし、完全なModdableアプリケーションのためのmanifest.jsonとmain.jsファイルを作成します。プロジェクトをビルドしてModdable Simulatorで実行するには、以下のコマンドを使用します。
 
-	cd <the folder you selected>
+	cd <選択したフォルダ>
 	mcconfig -m
 
 
-### Notes
+### 注釈
 
-The length of the total animation is taken from the AE composition.
+アニメーション全体の長さはAEコンポジションから取得されます。
 
-Time values are exported as milliseconds.
+時間値はミリ秒単位でエクスポートされます。
 
-AE easing is not exported but Moddable easing can be added to the exported code.
+AEのイージングはエクスポートされませんが、Moddableのイージングをエクスポートされたコードに追加することができます。
 
-Example: (null replaced by Math.quadEaseOut)
+例： (nullをMath.quadEaseOutに置き換え）
 
 	this.steps(ball, { x:ballX, y:ballY }, 2333, null, 0, 0);
 
 	this.steps(ball, { x:ballX, y:ballY }, 2333, Math.quadEaseOut, 0, 0);
+
 
 

--- a/documentation/piu/expanding-keyboard.md
+++ b/documentation/piu/expanding-keyboard.md
@@ -1,53 +1,53 @@
-# Expanding Keyboard Reference
+# 拡張キーボードのリファレンス
 Copyright 2019 Moddable Tech, Inc.<BR>
-Revised: July 2, 2019
+改訂： July 2, 2019
 
-The vertical and horizontal expanding keyboard modules implement touch screen keyboards for use with [Piu](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/piu/piu.md) on Moddable One and Moddable Two [products](https://www.moddable.com/product.php). The keys automatically expand when tapped, eliminating the need for a stylus. Both keyboards implement the same API.
+縦型および横型の拡張キーボードモジュールは、Moddable OneおよびModdable Two [製品](https://www.moddable.com/product.php)上で[Piu](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/piu/piu.md)と共に使用するためのタッチスクリーンキーボードを実装します。キーはタップすると自動的に拡大し、スタイラスを必要としません。両方のキーボードは同じAPIを実装しています。
 
-- **Source code:** [`vertical/keyboard.js`](../../modules/input/expanding-keyboard/vertical/keyboard.js) [`horizontal/keyboard.js`](../../modules/input/expanding-keyboard/horizontal/keyboard.js)
-- **Relevant Examples:** [vertical-expanding-keyboard](../../examples/piu/vertical-expanding-keyboard/main.js) [horizontal-expanding-keyboard](../../examples/piu/horizontal-expanding-keyboard/main.js)
+- **ソースコード:** [`vertical/keyboard.js`](../../modules/input/expanding-keyboard/vertical/keyboard.js) [`horizontal/keyboard.js`](../../modules/input/expanding-keyboard/horizontal/keyboard.js)
+- **関連するサンプル:** [vertical-expanding-keyboard](../../examples/piu/vertical-expanding-keyboard/main.js) [horizontal-expanding-keyboard](../../examples/piu/horizontal-expanding-keyboard/main.js)
 
-The keyboards are designed to fit a 240 x 320 screen. The vertical keyboard height is 185 pixels. The horizontal keyboard height is 164 pixels and designed to run in a landscape orientation. Both orientations fill the application screen width.
+キーボードは240 x 320の画面にフィットするように設計されています。縦型キーボードの高さは185ピクセルです。横型キーボードの高さは164ピクセルで、横向きで動作するように設計されています。どちらの向きでもアプリケーション画面の幅を埋めます。
 
-Key presses trigger events that can be captured in the application's behavior. The style (font and weight) of the keyboard's text are defined by a [`Style`](./piu.md#style-object) object supplied by the caller. This allows the use of `Style` templates.
+キー押下はアプリケーションの動作でキャプチャできるイベントをトリガーします。キーボードのテキストのスタイル（フォントとウェイト）は、呼び出し元が提供する[`Style`](./piu.md#style-object)オブジェクトによって定義されます。これにより、`Style`テンプレートを使用することができます。
 
-A `KeyboardField` container and associated behavior are additionally provided to facilitate integrating the keyboard into apps. This container displays the keys pressed along with a blinking I-beam cursor. The `KeyboardField` height should be tall enough to fit the I-beam cursor, which is outset from the field text.
+さらに、キーボードをアプリに統合するための`KeyboardField`コンテナと関連する動作が提供されています。このコンテナは、押されたキーと点滅するIビームカーソルを表示します。`KeyboardField`の高さは、フィールドテキストから外れたIビームカーソルが収まるのに十分な高さである必要があります。
 
-## Keyboard Module Exports
+## キーボードモジュールのエクスポート
 
-| Export | Type |  Description |
+| エクスポート | タイプ | 説明 |
 | :---: | :---: | :--- |
-| `VerticalExpandingKeyboard` | `constructor` | Constructor used to create vertical expanding keyboard instances. |
-| `HorizontalExpandingKeyboard` | `constructor` | Constructor used to create horizontal expanding keyboard instances. |
+| `VerticalExpandingKeyboard` | `constructor` | 垂直に拡張するキーボードインスタンスを作成するためのコンストラクタ。 |
+| `HorizontalExpandingKeyboard` | `constructor` | 水平方向に拡張するキーボードインスタンスを作成するためのコンストラクタ。 |
 
 ```js
 import {VerticalExpandingKeyboard} from "keyboard";
 import {HorizontalExpandingKeyboard} from "keyboard";
 ```
 
-## KeyboardField Module Exports
+## KeyboardField モジュールのエクスポート
 
-| Export | Type |  Description |
+| エクスポート | タイプ | 説明 |
 | :---: | :---: | :--- |
-| `KeyboardField` | `constructor` | Constructor used to create keyboard field instances. |
+| `KeyboardField` | `constructor` | キーボードフィールドインスタンスを作成するために使用されるコンストラクタ。 |
 
 ```js
 import {KeyboardField} from "common/keyboard";
 ```
 
-## Keyboard Objects
+## キーボードオブジェクト
 
-### Constructor Description
+### コンストラクタの説明
 
 #### `VerticalExpandingKeyboard(behaviorData, dictionary)`
 #### `HorizontalExpandingKeyboard(behaviorData, dictionary)`
 
-| Argument | Type | Description |
+| 引数 | タイプ | 説明 |
 | :---: | :---: | :--- |
-| `behaviorData`	| `*` |	A parameter that is passed into the `onCreate `function of the keyboard's `behavior`. This may be any type of object, including `null` or a dictionary with arbitrary parameters.
-| `dictionary` | `object` | An object with properties to configure the resulting keyboard. Only parameters specified in the [Dictionary](#keyboard-dictionary) section below will have an effect; other parameters will be ignored.
+| `behaviorData` | `*` | キーボードの `behavior` の `onCreate` 関数に渡されるパラメータ。これは `null` や任意のパラメータを持つ辞書を含む任意のタイプのオブジェクトである可能性があります。 |
+| `dictionary` | `object` | 結果として得られるキーボードを構成するプロパティを持つオブジェクト。以下の [Dictionary](#keyboard-dictionary) セクションで指定されたパラメータのみが効果を持ち、他のパラメータは無視されます。 |
 
-Returns a `VerticalExpandingKeyboard` or `HorizontalExpandingKeyboard` `Container` instance.
+`VerticalExpandingKeyboard` または `HorizontalExpandingKeyboard` の `Container` インスタンスを返します。
 
 ```js
 const KeyboardStyle = Style.template({ font:"18px Roboto", color:"black" });
@@ -57,74 +57,74 @@ let keyboard = new VerticalExpandingKeyboard(null, { Style:KeyboardStyle, target
 ![](../assets/piu/vertical-expanding-keyboard.png)
 
 <a id="keyboard-dictionary"></a>
-### Dictionary
+### 辞書
 
-| Parameter | Type | Default Value | Description |
+| パラメータ | 型 | デフォルト値 | 説明 |
 | :---: | :---: | :---: | :--- |
-| `Style` | `style` | n/a | **Required.** A Piu Style object that will be used for the text on keys. |
-| `target` | `object` | n/a | **Required.** A Piu Container object that will receive the `onKeyUp` event. |
-| `doTransition` | `boolean` | `false`| Whether or not to transition in the keyboard when it is first displayed and transition out when dismissed. |
+| `Style` | `style` | n/a | **必須。** キーのテキストに使用されるPiuスタイルオブジェクト。 |
+| `target` | `object` | n/a | **必須。** `onKeyUp`イベントを受け取るPiuコンテナオブジェクト。 |
+| `doTransition` | `boolean` | `false`| キーボードが最初に表示されるときにトランジションし、閉じられるときにトランジションするかどうか。 |
 
 <a id="key-callback"></a>
-### Triggered Events
+### トリガーイベント
 
 #### `onKeyboardOK(container, text)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
-| `text` | `string` | The complete string entered into the field |
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
+| `text` | `string` | フィールドに入力された完全な文字列 |
 
-The keyboard bubbles this event when the OK button is pressed.
+OKボタンが押されたときにキーボードがこのイベントをバブルします。
 
 #### `onKeyboardRowsContracted(container)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
 
-The keyboard bubbles this event when it is done horizontally contracting the keyboard rows back to the unzoomed view.
+キーボードが水平方向にキーボード行を元のズームされていないビューに戻すと、このイベントがバブルされます。
 
 #### `onKeyboardRowsExpanded(container)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
 
-The keyboard bubbles this event when it is done horizontally expanding the keyboard rows to the zoomed view.
+キーボードが水平方向にキーボード行をズームされたビューに拡張すると、このイベントがバブルされます。
 
 #### `onKeyboardTransitionFinished(container, out)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
-| `out` | `boolean` | Set `true` when the keyboard transitions out of view, `false` when the keyboard transitions into view |
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
+| `out` | `boolean` | キーボードがビューから外れるときに `true` を設定し、キーボードがビューに入るときに `false` を設定します |
 
-The keyboard bubbles this event when it is done transitioning on and off the screen. The `onKeyboardTransitionFinished` function will usually be implemented and triggered in the calling application's behavior.
+キーボードが画面のオンとオフを切り替えると、このイベントがバブルされます。`onKeyboardTransitionFinished` 関数は通常、呼び出し元アプリケーションのビヘイビアで実装され、トリガーされます。
 
 #### `onKeyUp(container, key)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
-| `key` | `string` | The string value of the key that was pressed (e.g., `'a'`, `'3'`, `'$'`). It can also be `\b` for backspace or `\r` for the submit button.|
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
+| `key` | `string` | 押されたキーの文字列値（例：`'a'`、`'3'`、`'$'`）。バックスペースの場合は `\b`、送信ボタンの場合は `\r` も可能です。|
 
-The keyboard bubbles the `onKeyUp` event when a key is released. The `onKeyUp` function will usually be implemented and triggered in the calling application's behavior.
+キーボードはキーが放されたときに `onKeyUp` イベントをバブルします。`onKeyUp` 関数は通常、呼び出し元アプリケーションのビヘイビアで実装され、トリガーされます。
 
 ***
 
-## KeyboardField Object
+## KeyboardField オブジェクト
 
-### Constructor Description
+### コンストラクタの説明
 
 #### `KeyboardField(behaviorData, dictionary)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `behaviorData`	| `*` |	A parameter that is passed into the `onCreate `function of the keyboard field's `behavior`. This may be any type of object, including `null` or a dictionary with arbitrary parameters.
-| `dictionary` | `object` | An object with properties to configure the resulting keyboard field. Only parameters specified in the [Dictionary](#keyboard-field-dictionary) section below will have an effect; other parameters will be ignored.
+| `behaviorData`	| `*` |	キーボードフィールドの `behavior` の `onCreate` 関数に渡されるパラメータ。このパラメータは任意の型のオブジェクトであり得ます。`null` や任意のパラメータを持つ辞書も含まれます。 |
+| `dictionary` | `object` | 結果として得られるキーボードフィールドを構成するプロパティを持つオブジェクト。以下の [Dictionary](#keyboard-field-dictionary) セクションで指定されたパラメータのみが効果を持ちます。他のパラメータは無視されます。 |
 
-Returns a `KeyboardField` `Container` instance.
+`KeyboardField` の `Container` インスタンスを返します。
 
 ```js
 const FieldStyle = Style.template({ font: "20px Open Sans", color: "black", horizontal:"left", vertical:"middle" });
@@ -134,19 +134,18 @@ let keyboardField = new KeyboardField(null, { Style:FieldStyle });
 <a id="keyboard-field-dictionary"></a>
 ### Dictionary
 
-| Parameter | Type | Default Value | Description |
+| パラメータ | 型 | デフォルト値 | 説明 |
 | :---: | :---: | :---: | :--- |
-| `Style` | `style` | n/a | **Required.** A Piu Style object that will be used for the keyboard entry text. |
-| `password` | `boolean` | `false` | Set `true` to enable password mode. The password mode hides each character displayed after a short delay. |
+| `Style` | `style` | n/a | **必須。** キーボード入力テキストに使用されるPiuスタイルオブジェクト。 |
+| `password` | `boolean` | `false` | パスワードモードを有効にするには`true`を設定します。パスワードモードでは、短時間表示された後に各文字が隠されます。 |
 
-### Triggered Events
+### トリガーイベント
 
 #### `onKeyboardOK(container, text)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `container` | `object` | The behavior's Container object |
-| `text` | `string` | The complete string entered into the field |
+| `container` | `object` | ビヘイビアのコンテナオブジェクト |
+| `text` | `string` | フィールドに入力された完全な文字列 |
 
-The keyboard bubbles this event when the OK button is pressed.
-
+OKボタンが押されたときにキーボードがこのイベントをバブルします。

--- a/documentation/piu/keyboard.md
+++ b/documentation/piu/keyboard.md
@@ -1,40 +1,41 @@
-# Keyboard
+# キーボード
 
-The Keyboard module implements a touch screen keyboard with a responsive layout for use with Piu.
+キーボードモジュールは、Piuで使用するためのレスポンシブレイアウトを備えたタッチスクリーンキーボードを実装します。
 
-- **Source code:** [`keyboard.js`](../../modules/input/keyboard/keyboard.js)
-- **Relevant Example:** [keyboard](../../examples/piu/keyboard/main.js)
+- **ソースコード:** [`keyboard.js`](../../modules/input/keyboard/keyboard.js)
+- **関連するサンプル:** [keyboard](../../examples/piu/keyboard/main.js)
 
-The keyboard is implemented using a [`Port`](./piu.md#port-object) object that automatically fills its parent container, allowing it to reflow in a manner controlled by the application. The dictionary passed to the constructor configures properties of the keyboard.
+キーボードは、親コンテナを自動的に埋める[`Port`](./piu.md#port-object)オブジェクトを使用して実装されており、アプリケーションによって制御される方法でリフローすることができます。コンストラクタに渡される辞書は、キーボードのプロパティを構成します。
 
-Key presses trigger events that can be captured in the application's behavior. The style (font and weight) of the keyboard's text are driven by a [`Style`](./piu.md#style-object) object supplied by the caller. This allows the use of `Style` templates.
+キー押下は、アプリケーションの動作でキャプチャできるイベントをトリガーします。キーボードのテキストのスタイル（フォントとウェイト）は、呼び出し元が提供する[`Style`](./piu.md#style-object)オブジェクトによって駆動されます。これにより、`Style`テンプレートを使用することができます。
 
-The keyboard implements a `doKeyboardTransitionOut` event that can be triggered to cause the keyboard to transition off-screen. When the transition is complete, the keyboard triggers an event to notify the application.
+キーボードは、キーボードを画面外に移行させるためにトリガーできる`doKeyboardTransitionOut`イベントを実装しています。移行が完了すると、キーボードはアプリケーションに通知するイベントをトリガーします。
 
-## Module Exports
+## モジュールエクスポート
 
-| Export | Type |  Description |
+
+| エクスポート | 型 |  説明 |
 | :---: | :---: | :--- |
-| `Keyboard` | `constructor` | Constructor used to create Keyboard instances. |
-| `BACKSPACE` | `string` | Constant used to indicate that the backspace key was pressed. |
-| `SUBMIT` | `string` | Constant used to indicate that the submit key was pressed. |
+| `Keyboard` | `constructor` | キーボードインスタンスを作成するために使用されるコンストラクタ。 |
+| `BACKSPACE` | `string` | バックスペースキーが押されたことを示すために使用される定数。 |
+| `SUBMIT` | `string` | サブミットキーが押されたことを示すために使用される定数。 |
 
 ```js
 import {Keyboard, BACKSPACE, SUBMIT} from "keyboard";
 ```
 
-## Keyboard Object
+## キーボードオブジェクト
 
-### Constructor Description
+### コンストラクタの説明
 
 #### `Keyboard(behaviorData, dictionary)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `behaviorData`	| `*` |	A parameter that is passed into the `onCreate `function of the keyboard's `behavior`. This may be any type of object, including `null` or a dictionary with arbitrary parameters.
-| `dictionary` | `object` | An object with properties to configure the resulting keyboard. Only parameters specified in the [Dictionary](#keyboard-dictionary) section below will have an effect; other parameters will be ignored.
+| `behaviorData`	| `*` |	キーボードの `behavior` の `onCreate` 関数に渡されるパラメータ。これは `null` や任意のパラメータを持つ辞書を含む任意のタイプのオブジェクトである可能性があります。 |
+| `dictionary` | `object` | 結果として得られるキーボードを構成するためのプロパティを持つオブジェクト。以下の [Dictionary](#keyboard-dictionary) セクションで指定されたパラメータのみが効果を持ち、他のパラメータは無視されます。
 
-Returns a `keyboard` instance, a `Port` object that uses an instance of the `KeyboardBehavior` class as its behavior.
+`keyboard` インスタンス、つまりその動作として `KeyboardBehavior` クラスのインスタンスを使用する `Port` オブジェクトを返します。
 
 ```js
 let OpenSans18 = new Style({ font: "semibold 18px Open Sans", color: "black" });
@@ -44,59 +45,58 @@ let keyboard = new Keyboard(null, {style: OpenSans18, doTransition: false})
 ![](../assets/piu/keyboard.png)
 
 <a id="keyboard-dictionary"></a>
-### Dictionary
+### 辞書
 
-| Parameter | Type | Default Value | Description |
+| パラメータ | 型 | デフォルト値 | 説明 |
 | :---: | :---: | :---: | :--- |
-| `style` | `style` | n/a | **Required.** A Piu Style object that will be used for the text on keys. |
-| `bgColor` | `string` | `"#5b5b5b"`| The background fill color. |
-| `doTransition` | `boolean` | `false`| Whether or not to transition in the keyboard when it is first displayed. |
-| `keyColor` | `string` | `"#d8d8d8"`| The color for the character keys when not being pressed. |
-| `keyDownColor` | `string` | `"#999999"`| The color for the character keys while they are being pressed. |
-| `keyToggledColor` | `string` | `"#7b7b7b"`| The color for the character keys while they are being pressed. |
-| `specialKeyColor` | `string` | `"#999999"`| The color for the special keys (shift, symbol, backspace, and submit) when not being pressed. |
-| `specialTextColor` | `string` | `"#ffffff"`| The color for the text on special keys (shift, symbol, backspace, and submit). |
-| `submit` | `string` | `"OK"`| String to render on the submit key. |
-| `textColor` | `string` | `"#000000"`| The color for the text on character keys. |
-| `transitionTime` | `number` | `250`| The duration of the keyboard in/out transition in milliseconds. |
+| `style` | `style` | n/a | **必須。** キーのテキストに使用されるPiu Styleオブジェクト。 |
+| `bgColor` | `string` | `"#5b5b5b"`| 背景の塗りつぶし色。 |
+| `doTransition` | `boolean` | `false`| キーボードが最初に表示されるときにトランジションするかどうか。 |
+| `keyColor` | `string` | `"#d8d8d8"`| 押されていないときの文字キーの色。 |
+| `keyDownColor` | `string` | `"#999999"`| 押されているときの文字キーの色。 |
+| `keyToggledColor` | `string` | `"#7b7b7b"`| 押されているときの文字キーの色。 |
+| `specialKeyColor` | `string` | `"#999999"`| 押されていないときの特殊キー（シフト、シンボル、バックスペース、送信）の色。 |
+| `specialTextColor` | `string` | `"#ffffff"`| 特殊キー（シフト、シンボル、バックスペース、送信）のテキストの色。 |
+| `submit` | `string` | `"OK"`| 送信キーに表示される文字列。 |
+| `textColor` | `string` | `"#000000"`| 文字キーのテキストの色。 |
+| `transitionTime` | `number` | `250`| キーボードのイン/アウトトランジションの持続時間（ミリ秒）。 |
 
 <a id="key-callback"></a>
-### Triggered Events
+### トリガーされたイベント
 
 #### `onKeyboardTransitionFinished()`
-The keyboard will bubble this event when it is done transitioning off-screen. The `onKeyboardTransitionFinished` function will usually be implemented and triggered in the calling application's behavior.
+キーボードが画面外に移行し終わったときに、このイベントがバブルされます。`onKeyboardTransitionFinished` 関数は通常、呼び出し元アプリケーションの動作で実装され、トリガーされます。
 
 ***
 
 #### `onKeyDown(key)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `key` | `string` | In most cases, the string will be the value of the key that is down (e.g. `"a"`, `"3"`, `"$"`). It can also be one of the two constants exported by the module:  `BACKSPACE` or `SUBMIT` which indicate that those keys are down on the keyboard.|
+| `key` | `string` | ほとんどの場合、文字列は押されたキーの値になります（例: `"a"`, `"3"`, `"$"`）。また、モジュールによってエクスポートされる2つの定数のいずれかである場合もあります: `BACKSPACE` または `SUBMIT`。これらはキーボード上でそのキーが押されたことを示します。|
 
-The keyboard will bubble this event when a key is pressed down. The `onKeyDown` function will usually be implemented and triggered in the calling application's behavior.
-
+キーボードがキーを押されたときに、このイベントがバブルされます。`onKeyDown` 関数は通常、呼び出し元アプリケーションの動作で実装され、トリガーされます。
 
 ***
 
 #### `onKeyUp(key)`
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `key` | `string` | In most cases, the string will be the value of the key that was released (e.g. `"a"`, `"3"`, `"$"`). It can also be one of the two constants exported by the module:  `BACKSPACE` or `SUBMIT` which indicate that those keys were released on the keyboard.|
+| `key` | `string` | ほとんどの場合、文字列は放されたキーの値になります（例: `"a"`, `"3"`, `"$"`）。また、モジュールによってエクスポートされる2つの定数のいずれかである場合もあります: `BACKSPACE` または `SUBMIT`。これらはキーボード上でそのキーが放されたことを示します。|
 
-The keyboard will bubble an event `onKeyUp` when a key is released. The `onKeyUp` function will usually be implemented and triggered in the calling application's behavior.
+キーボードはキーが放されたときに `onKeyUp` イベントをバブルします。`onKeyUp` 関数は通常、呼び出し元アプリケーションの動作で実装され、トリガーされます。
 
 ***
 
-### Received Events
+### 受信イベント
 
-#### `doKeyboardTransitionOut(keyboard)`
+#### `doKeyboardTransitionOut(keyboard)` {#examples}
 
-| Argument | Type | Description |
+| 引数 | 型 | 説明 |
 | :---: | :---: | :--- |
-| `keyboard` | `keyboard` | The `keyboard` object that received the event. |
+| `keyboard` | `keyboard` | イベントを受信した `keyboard` オブジェクト。 |
 
-This function can be triggered to cause the keyboard to transition off screen. When the transition is complete, the `onKeyboardTransitionFinished` event will be bubbled by the keyboard.
+この関数は、キーボードを画面外に移行させるためにトリガーされることがあります。移行が完了すると、キーボードによって `onKeyboardTransitionFinished` イベントがバブルされます。
 
 ***


### PR DESCRIPTION
以下の翻訳になります。 @meganetaaan さん、レビューお願いします
[/documentation/piu/ae%20motion%20export.md](https://github.com/moddable-OpenSource/moddable-jp/blob/dev/translate-jp/documentation/piu/ae%20motion%20export.md)
[/documentation/piu/expanding-keyboard.md](https://github.com/moddable-OpenSource/moddable-jp/blob/dev/translate-jp/documentation/piu/expanding-keyboard.md)
[/documentation/piu/keyboard.md](https://github.com/moddable-OpenSource/moddable-jp/blob/dev/translate-jp/documentation/piu/keyboard.md)